### PR TITLE
ci: bump asdf-vm/actions from v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,6 @@ jobs:
           brew install gettext
           echo /usr/local/opt/gettext/bin >> "$GITHUB_PATH"
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v3
+        uses: asdf-vm/actions/plugin-test@v4
         with:
           command: git version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: asdf-vm/actions/install@v3
+      - uses: asdf-vm/actions/install@v4
       - run: scripts/lint.bash
 
   actionlint:


### PR DESCRIPTION
## Summary

The CI was failing on both the Build and Lint workflows. `asdf-vm/actions@v3` runs on the now-deprecated Node 20 runtime, and it also fails against current asdf with:

```
Error: Unable to locate executable file: asdf.
```

Bumping to `asdf-vm/actions@v4` moves the actions to the Node 24 runtime and fixes the executable lookup.

## Changes

- `.github/workflows/build.yml`: `asdf-vm/actions/plugin-test@v3` → `@v4`
- `.github/workflows/lint.yml`: `asdf-vm/actions/install@v3` → `@v4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)