### PR TITLE
build(devcontainer): allow installing the latest Git via mise/asdf-git

### DIFF
--- a/.devcontainer/.env.additional.example
+++ b/.devcontainer/.env.additional.example
@@ -1,0 +1,3 @@
+# GH_TOKEN=
+
+# BUNDLE_GITHUB__COM=

--- a/.devcontainer/.gitignore
+++ b/.devcontainer/.gitignore
@@ -1,0 +1,1 @@
+/.env.additional

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     gpg \
     gnupg \
     build-essential \
+    cargo \
     libssl-dev \
     libyaml-dev \
     libreadline6-dev \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,52 @@
+FROM mcr.microsoft.com/devcontainers/base:debian-13
+
+# Install git, gh, Chromium, and other dependencies
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    git \
+    gh \
+    openssh-client \
+    iptables \
+    curl \
+    ca-certificates \
+    gpg \
+    gnupg \
+    build-essential \
+    libssl-dev \
+    libyaml-dev \
+    libreadline6-dev \
+    zlib1g-dev \
+    libncurses5-dev \
+    libffi-dev \
+    libgdbm6 \
+    libgdbm-dev \
+    dbus \
+    kmod \
+    chromium \
+    chromium-driver \
+    wget
+
+# Install mise
+RUN install -dm 755 /etc/apt/keyrings \
+    && wget -qO - https://mise.jdx.dev/gpg-key.pub | gpg --dearmor -o /etc/apt/keyrings/mise-archive-keyring.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=amd64] https://mise.jdx.dev/deb stable main" | tee /etc/apt/sources.list.d/mise.list \
+    && apt-get update \
+    && apt-get install -y mise
+
+USER vscode
+ENV MISE_DATA_DIR=/home/vscode/.local/share/mise
+ENV MISE_CONFIG_DIR=/home/vscode/.config/mise
+ENV PATH="/home/vscode/.local/bin:/home/vscode/.local/share/mise/shims:${PATH}"
+
+# Install tools
+RUN mise use -g node@24
+RUN npm install -g @devcontainers/cli
+# Install Claude Code via the native installer (https://code.claude.com/docs/ja/quickstart)
+RUN curl -fsSL https://claude.ai/install.sh | bash
+# Antigravity CLI is distributed as a native binary (installed to ~/.local/bin/agy), not via npm
+RUN curl -fsSL https://antigravity.google/cli/install.sh | bash
+RUN mise use -g ruby@latest
+
+# Setup shell for mise
+RUN echo 'eval "$(mise activate bash)"' >> ~/.bashrc \
+    && echo 'eval "$(mise activate zsh)"' >> ~/.zshrc

--- a/.devcontainer/allow_hosts.d/00-github
+++ b/.devcontainer/allow_hosts.d/00-github
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eu
+
+# Fixed domains
+cat <<EOF
+github.com
+api.github.com
+docs.github.com
+objects.githubusercontent.com
+EOF
+
+# GitHub IP ranges (IPv4 only)
+#
+# https://docs.github.com/ja/rest/meta/meta?apiVersion=2026-03-10#get-github-meta-information
+curl -s -H "Accept: application/vnd.github+json" https://api.github.com/meta | \
+  jq -r '.git[], .web[], .api[], .actions[], .packages[], .pages[]' | \
+  grep -E '^([0-9]{1,3}\.){3}[0-9]{1,3}(/[0-9]{1,2})?$' | \
+  sort -u

--- a/.devcontainer/allow_hosts.d/10-package-manager-rubygems
+++ b/.devcontainer/allow_hosts.d/10-package-manager-rubygems
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -eu
+
+cat <<EOF
+rubygems.org
+index.rubygems.org
+EOF

--- a/.devcontainer/allow_hosts.d/15-package-manager-npm
+++ b/.devcontainer/allow_hosts.d/15-package-manager-npm
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eu
+
+cat <<EOF
+registry.npmjs.org
+EOF

--- a/.devcontainer/allow_hosts.d/16-anthropic
+++ b/.devcontainer/allow_hosts.d/16-anthropic
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -eu
+
+echo "api.anthropic.com"
+# Claude Code native installer download / background auto-update endpoints
+echo "claude.ai"
+echo "downloads.claude.ai"

--- a/.devcontainer/allow_hosts.d/20-google
+++ b/.devcontainer/allow_hosts.d/20-google
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eu
+
+cat <<EOF
+cloudcode-pa.googleapis.com
+oauth2.googleapis.com
+www.gstatic.com
+generativelanguage.googleapis.com
+EOF
+
+# https://knowledge.workspace.google.com/admin/security/obtain-google-ip-address-ranges
+curl -s https://www.gstatic.com/ipranges/goog.json | \
+  jq -r '.prefixes[] | select(.ipv4Prefix != null) | .ipv4Prefix' | \
+  grep -E '^([0-9]{1,3}\.){3}[0-9]{1,3}(/[0-9]{1,2})?$'

--- a/.devcontainer/allow_hosts.d/21-antigravity
+++ b/.devcontainer/allow_hosts.d/21-antigravity
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eu
+
+# Antigravity CLI (agy): install script / OAuth callback, the auto-updater
+# (Cloud Run), and the binary download bucket. The Google API endpoints it
+# talks to (cloudcode-pa.googleapis.com, oauth2.googleapis.com, etc.) are
+# already covered by 20-google.
+cat <<EOF
+antigravity.google
+antigravity-cli-auto-updater-974169037036.us-central1.run.app
+storage.googleapis.com
+accounts.google.com
+EOF

--- a/.devcontainer/allow_hosts.d/30-debian
+++ b/.devcontainer/allow_hosts.d/30-debian
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -eu
+
+cat <<EOF
+deb.debian.org
+security.debian.org
+EOF

--- a/.devcontainer/allow_hosts.d/40-docker
+++ b/.devcontainer/allow_hosts.d/40-docker
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -eu
+
+sed -E -e '/^\s*#|^\s*$/ d' <<EOF
+# docker login
+index.docker.io
+
+# Docker Engine installation
+download.docker.com
+
+# webg --text --css-selector='table .link' https://docs.docker.com/desktop/setup/allow-list/ |
+# sed -E -e 's|^https?://||' |
+# sort
+api.docker.com
+api.dso.docker.com
+auth.docker.com
+auth.docker.io
+cdn.auth0.com
+desktop.docker.com
+dhi.io
+docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com
+docker-pinata-support.s3.amazonaws.com
+hub.docker.com
+login.docker.com
+notify.bugsnag.com
+production.cloudflare.docker.com
+registry-1.docker.io
+registry.scout.docker.com
+sessions.bugsnag.com
+EOF

--- a/.devcontainer/allow_hosts.d/50-mise
+++ b/.devcontainer/allow_hosts.d/50-mise
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eu
+
+cat <<EOF
+mise.jdx.dev
+EOF

--- a/.devcontainer/allow_hosts.d/60-microsoft
+++ b/.devcontainer/allow_hosts.d/60-microsoft
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+cat <<EOF
+mcr.microsoft.com
+ghcr.io
+pkg-containers.githubusercontent.com
+EOF

--- a/.devcontainer/allow_hosts.d/70-git-scm
+++ b/.devcontainer/allow_hosts.d/70-git-scm
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+# Git source tarballs downloaded by this asdf-git plugin
+# (see lib/utils.bash: download_release)
+cat <<EOF
+mirrors.edge.kernel.org
+EOF

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+  "name": "Mise & Antigravity CLI Dev Container",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "latest",
+      "moby": false
+    }
+  },
+  "mounts": [
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.claude.json,target=/home/vscode/.claude.json,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.gemini,target=/home/vscode/.gemini,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached"
+  ],
+  "capAdd": [
+    "NET_ADMIN"
+  ],
+  "initializeCommand": "./.devcontainer/initialize-command.sh",
+  "runArgs": [
+    "--init",
+    "--env-file",
+    ".devcontainer/.env.additional"
+  ],
+  "overrideCommand": true,
+  "postStartCommand": "sudo bash .devcontainer/setup-firewall.sh && bash .devcontainer/setup-known-hosts.sh",
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": true,
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode-remote.remote-containers",
+        "shopify.ruby-lsp",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  }
+}

--- a/.devcontainer/initialize-command.sh
+++ b/.devcontainer/initialize-command.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eux
+
+test -f .devcontainer/.env.additional ||
+  touch .devcontainer/.env.additional

--- a/.devcontainer/setup-firewall.sh
+++ b/.devcontainer/setup-firewall.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -eu
+
+echo "Generating firewall rules..."
+
+# Use a temporary file for iptables-restore
+RULES_FILE=$(mktemp)
+TMP_ENTRIES=$(mktemp)
+trap 'rm -f "$RULES_FILE" "$TMP_ENTRIES"' EXIT
+
+cat <<EOF > "$RULES_FILE"
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+
+# Flush existing rules in standard chains
+-F INPUT
+-F OUTPUT
+-X
+
+# Allow loopback
+-A INPUT -i lo -j ACCEPT
+-A OUTPUT -o lo -j ACCEPT
+
+# Allow established and related connections
+-A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+-A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+# Allow DNS (port 53 UDP/TCP)
+-A OUTPUT -p udp --dport 53 -j ACCEPT
+-A OUTPUT -p tcp --dport 53 -j ACCEPT
+
+# Allow Google Public DNS (8.8.8.8, 8.8.4.4) for 53, 443, 853
+-A OUTPUT -p udp -d 8.8.8.8 --dport 53 -j ACCEPT
+-A OUTPUT -p tcp -d 8.8.8.8 --dport 53 -j ACCEPT
+-A OUTPUT -p tcp -d 8.8.8.8 --dport 443 -j ACCEPT
+-A OUTPUT -p tcp -d 8.8.8.8 --dport 853 -j ACCEPT
+
+-A OUTPUT -p udp -d 8.8.4.4 --dport 53 -j ACCEPT
+-A OUTPUT -p tcp -d 8.8.4.4 --dport 53 -j ACCEPT
+-A OUTPUT -p tcp -d 8.8.4.4 --dport 443 -j ACCEPT
+-A OUTPUT -p tcp -d 8.8.4.4 --dport 853 -j ACCEPT
+EOF
+
+# Process all entries from allow_hosts.d
+run-parts .devcontainer/allow_hosts.d/ > "$TMP_ENTRIES"
+
+# Use awk to handle IP/CIDR entries efficiently
+awk '
+  /^[0-9.]+(\/[0-9]+)?$/ {
+    printf("-A OUTPUT -p tcp -d %s --dport 80 -j ACCEPT\n", $1)
+    printf("-A OUTPUT -p tcp -d %s --dport 443 -j ACCEPT\n", $1)
+  }
+' "$TMP_ENTRIES" >> "$RULES_FILE"
+
+# Now handle domains
+grep -vE '^[0-9.]+(\/[0-9]+)?$' "$TMP_ENTRIES" | while read -r domain; do
+  [ -z "$domain" ] && continue
+  IPS=$(getent ahosts "$domain" | awk '{print $1}' | sort -u | grep -E '^[0-9.]+$')
+  for ip in $IPS; do
+    printf -- "-A OUTPUT -p tcp -d %s --dport 80 -j ACCEPT\n" "$ip" >> "$RULES_FILE"
+    printf -- "-A OUTPUT -p tcp -d %s --dport 443 -j ACCEPT\n" "$ip" >> "$RULES_FILE"
+    if [ "$domain" = "github.com" ]; then
+      printf -- "-A OUTPUT -p tcp -d %s --dport 22 -j ACCEPT\n" "$ip" >> "$RULES_FILE"
+    fi
+  done
+done
+
+# Reject all other output immediately
+# Use tcp-reset for TCP to get immediate Connection Refused
+# Use icmp-port-unreachable for others
+cat <<EOF >> "$RULES_FILE"
+-A OUTPUT -p tcp -j REJECT --reject-with tcp-reset
+-A OUTPUT -j REJECT --reject-with icmp-port-unreachable
+COMMIT
+EOF
+
+echo "Applying firewall rules using iptables-restore..."
+iptables-restore -w < "$RULES_FILE"
+
+echo "Firewall rules applied."

--- a/.devcontainer/setup-known-hosts.sh
+++ b/.devcontainer/setup-known-hosts.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eu
+
+# Hosts to scan for SSH host keys.
+HOSTS="github.com"
+
+KNOWN_HOSTS="${HOME}/.ssh/known_hosts"
+
+mkdir -p "${HOME}/.ssh"
+chmod 700 "${HOME}/.ssh"
+
+touch "${KNOWN_HOSTS}"
+chmod 600 "${KNOWN_HOSTS}"
+
+for host in ${HOSTS}; do
+  echo "Scanning SSH host keys for ${host}..."
+
+  # Fetch the current host keys.
+  keys=$(ssh-keyscan "${host}")
+
+  # Remove existing entries for this host to avoid duplicates, then append the
+  # freshly fetched keys.
+  ssh-keygen -R "${host}" -f "${KNOWN_HOSTS}" >/dev/null 2>&1 || true
+  echo "${keys}" >> "${KNOWN_HOSTS}"
+
+  echo "Added SSH host keys for ${host} to ${KNOWN_HOSTS}."
+done

--- a/.devcontainer/test.sh
+++ b/.devcontainer/test.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+set -eux
+
+devcontainer --version
+agy --version
+
+devcontainer build
+devcontainer up --workspace-folder . --remove-existing-container
+exec devcontainer exec bash -eux -c '
+  ruby --version
+  gem install rake
+
+  node --version
+  npm install -g es6-map
+
+  devcontainer --version
+
+  # Verify connectivity to AI API endpoints (Firewall test)
+  # Even with dummy keys, these should connect (getting 401/403/404 instead of timeout/refusal)
+  check_connectivity() {
+    local url=$1
+    echo "Testing connectivity to $url..."
+    if curl -I -s --max-time 10 "$url" > /dev/null; then
+      echo "Connectivity to $url: OK"
+    else
+      local exit_code=$?
+      echo "Connectivity to $url: FAILED (curl exit code: $exit_code)"
+      return 1
+    fi
+  }
+
+  check_connectivity "https://antigravity.google/"
+  check_connectivity "https://api.anthropic.com/"
+
+  # Detect Antigravity connection
+  # Antigravity CLI authenticates via browser-based Google sign-in and stores
+  # its credentials under ~/.gemini. "agy models" requires a valid login, so we
+  # use it to probe whether the CLI is authenticated.
+  agy_authed=false
+  if agy models >/dev/null 2>&1
+  then
+    agy_authed=true
+  fi
+
+  agy --version
+  if test "$agy_authed" = "true"
+  then
+    agy --print "Hello, World!"
+  else
+    agy --print --print-timeout 30s "Hello, World!" || echo "Antigravity prompt failed as expected without credentials"
+  fi
+
+  # Detect Claude connection
+  claude_authed=false
+  case "${ANTHROPIC_API_KEY:-}" in
+    ""|dummy)
+      ;;
+    *)
+      claude_authed=false
+      ;;
+  esac
+  if test -f "$HOME/.claude/.credentials.json" && ! grep -q "dummy" "$HOME/.claude/.credentials.json"
+  then
+    claude_authed=true
+  fi
+
+  claude --version
+  if test "$claude_authed" = true
+  then
+    claude --no-session-persistence --print "Hello, World!"
+  else
+    claude --no-session-persistence --print "Hello, World!" || echo "Claude prompt failed as expected with dummy credentials"
+  fi
+
+  # Check GitHub CLI connection
+  gh version
+  GH_TOKEN=dummy gh api https://github.com/nishidayuya/dot-devcontainer
+'


### PR DESCRIPTION
## Summary

Make it possible to install the latest Git through mise (using this repository's asdf-git plugin) inside the devcontainer.

Two things were blocking it:

1. **Firewall** — the plugin downloads Git source tarballs from `mirrors.edge.kernel.org` (see `lib/utils.bash`: `download_release`), but that host was not in the firewall allow list, so the download was rejected.
2. **Build toolchain** — recent Git releases (2.55.0+) build a Rust component (`libgitcore`) during compilation, which requires a Rust toolchain. Without it the build failed with `make: Error 127` (cargo not found).

## Changes

- Add `.devcontainer/allow_hosts.d/70-git-scm` to allow `mirrors.edge.kernel.org`.
- Add Debian's `cargo` package (it pulls in `rustc`) to the devcontainer build dependencies in `.devcontainer/Dockerfile`.

The `gitcore` crate has no external dependencies, so the cargo build stays offline and needs no additional firewall hosts.

## Verification

- Brought up the devcontainer with `devcontainer up` (image built with `cargo`, `postStartCommand` applied the firewall rules including the new host).
- Inside the freshly launched container, linked this repository's asdf-git plugin and ran `mise install git@2.55.0` (the latest version) — it succeeded.
- `mise exec git@2.55.0 -- git --version` reported `git version 2.55.0`.
- Also confirmed an older, Rust-free version (`git@2.51.2`) still installs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)