### PR TITLE
feat(install): build and install bundled contrib commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,32 @@ git version
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to
 install & manage versions.
 
+## Contrib commands
+
+Git ships extra commands under the `contrib/` directory of its source tarball.
+By default this plugin builds and installs **every** contrib command whose
+`Makefile` provides an `install` target (for example `git subtree`):
+
+```shell
+git subtree --help
+```
+
+A contrib command that fails to build (for example a platform-specific one such
+as `credential/wincred` on non-Windows systems) is reported and skipped without
+aborting the Git installation.
+
+You can choose exactly which contrib commands to install with the
+`ASDF_GIT_CONTRIBS` environment variable (a space-separated list of paths
+relative to `contrib/`):
+
+```shell
+# Install only git-subtree and git-contacts
+ASDF_GIT_CONTRIBS="subtree contacts" asdf install git latest
+
+# Skip installing contrib commands entirely
+ASDF_GIT_CONTRIBS="" asdf install git latest
+```
+
 # Contributing
 
 Contributions of any kind welcome! See the [contributing guide](contributing.md).

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -51,6 +51,58 @@ download_release() {
 	curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
 }
 
+# Print the contrib commands (paths relative to contrib/, e.g. "subtree" or
+# "credential/netrc") whose Makefile provides an `install` target.
+list_installable_contribs() {
+	local contrib_base="$ASDF_DOWNLOAD_PATH/contrib"
+	local makefile dir
+
+	while IFS= read -r makefile; do
+		if grep -q '^install:' "$makefile"; then
+			dir="$(dirname "$makefile")"
+			echo "${dir#"$contrib_base"/}"
+		fi
+	done < <(find "$contrib_base" -name Makefile | sort)
+}
+
+install_contribs() {
+	local install_path="$1"
+	local contrib_base="$ASDF_DOWNLOAD_PATH/contrib"
+	local contribs contrib contrib_dir
+
+	# ASDF_GIT_CONTRIBS is a space-separated list of contrib commands to install
+	# (see lib/utils.bash documentation in README). When it is unset, every
+	# contrib command that provides an install target is installed; when it is
+	# set to an empty string, no contrib command is installed.
+	if [ -n "${ASDF_GIT_CONTRIBS+set}" ]; then
+		contribs="$ASDF_GIT_CONTRIBS"
+	else
+		contribs="$(list_installable_contribs)"
+	fi
+
+	for contrib in $contribs; do
+		contrib_dir="$contrib_base/$contrib"
+
+		if [ ! -d "$contrib_dir" ]; then
+			echo "* Skipping contrib '$contrib': not found in this $TOOL_NAME source."
+			continue
+		fi
+		if ! grep -q '^install:' "$contrib_dir/Makefile" 2>/dev/null; then
+			echo "* Skipping contrib '$contrib': no install target in its Makefile."
+			continue
+		fi
+
+		echo "* Installing contrib '$contrib'..."
+		# gitexecdir defaults to $(prefix)/libexec/git-core, matching where the
+		# main `make install` placed Git's own commands, so `git $contrib` works.
+		# A single contrib failure (e.g. a platform-specific one) must not abort
+		# the whole Git installation, so it is reported and skipped.
+		if ! make -C "$contrib_dir" "-j$(nproc)" prefix="$install_path" install; then
+			echo "* Warning: could not install contrib '$contrib'; skipping it."
+		fi
+	done
+}
+
 install_version() {
 	local install_type="$1"
 	local version="$2"
@@ -66,6 +118,8 @@ install_version() {
 		./configure --prefix="$install_path"
 		make "-j$(nproc)"
 		make install
+
+		install_contribs "$install_path"
 
 		# Assert git executable exists.
 		local tool_cmd


### PR DESCRIPTION
## Summary

Install the contrib commands shipped in the Git source tarball (e.g. `git subtree`) alongside Git itself.

- By default, **every** contrib command whose `Makefile` provides an `install` target is built and installed into `libexec/git-core`, so commands like `git subtree` and `git contacts` work out of the box.
- A contrib command that fails to build (e.g. a platform-specific one such as `credential/wincred` on non-Windows systems) is reported and skipped without aborting the Git installation.
- The set of contrib commands can be overridden via the `ASDF_GIT_CONTRIBS` environment variable: a space-separated list of paths relative to `contrib/`, or an empty string to skip them entirely.

## Implementation

- Add `list_installable_contribs` to discover contrib directories that provide a Makefile `install` target.
- Add `install_contribs`, called right after the main `make install`, which installs the selected contrib commands. Per-contrib failures are non-fatal.
- `gitexecdir` defaults to `$(prefix)/libexec/git-core`, matching where the main `make install` placed Git's own commands, so `git <contrib>` resolves correctly.
- Document the behavior and `ASDF_GIT_CONTRIBS` in the README.

## Verification

Built Git 2.43.0 end-to-end via `bin/download` + `bin/install`:

- `git subtree -h` and `git contacts` work; `git-subtree`, `git-contacts`, `git-credential-netrc` are installed under `libexec/git-core`.
- With `ASDF_GIT_CONTRIBS` unset, all detected contribs are attempted; `credential/wincred` (Windows-only) and `mw-to-git` fail and are skipped with a warning while Git itself installs successfully.
- `ASDF_GIT_CONTRIBS=""` skips contrib installation; an explicit list installs only the requested commands.
- `shellcheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)